### PR TITLE
2022-es alapszabály

### DIFF
--- a/CHOK/chok.tex
+++ b/CHOK/chok.tex
@@ -1,7 +1,7 @@
 \documentclass{../styles/rulebook}
 
 \begin{document}
-\section*{ELTE Eötvös József Collegium \\ \vspace{0.5em} Hallgatói Önkormányzat -- Alapszabály}
+\section*{ELTE Eötvös József Collegium \\ \vspace{0.5em} Hallgatói Önkormányzat Alapszabálya}
 
 \vspace{2em}
 
@@ -15,16 +15,36 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 \begin{enumerate}
 	\item Az Önkormányzat 
 	\begin{enumerate}
-		\item neve: Collegium Hallgatói Önkormányzata, 
+		\item neve: Collegium Hallgatói Önkormányzata,
 		\item székhelye: 1118 Budapest, Ménesi út 11--13.,
 		\item nemzetközi neve: Students’ Council of Eötvös József Collegium.
 	\end{enumerate}
-	\item A CHÖK a Collegium hallgatóinak a felsőoktatásról szóló, 2011. évi CCIV. törvény alapján létrehozott, demokratikus elven működő érdekképviseleti szervezete, amely kizárólagosan gyakorolja a hallgatói jogviszonyból eredő kollektív hallgatói jogokat, illetve a jogszabályokban és a collegiumi szabályzatokban ráruházott hatásköröket. 
-	\item A CHÖK tagja a Collegium minden bentlakó és bejáró aktív jogviszonyú hallgatója, valamint bentlakó és bejáró seniorja.
+	\item A CHÖK tagjainak fenntarthatósággal kapcsolatos kötelezettségeit a Szelektív hulladékgyűjtési és komposztálási melléklet rendezi, ez a jelen dokumentum 1. számú melléklete.
+	\item A CHÖK a Collegium hallgatóinak a felsőoktatásról szóló, 2011. évi CCIV. törvény alapján létrehozott, demokratikus elven működő érdekképviseleti szervezete, amely kizárólagosan gyakorolja a hallgatói jogviszonyból eredő kollektív hallgatói jogokat, illetve a jogszabályokban és a collegiumi szabályzatokban ráruházott hatásköröket.
+	\item A CHÖK tagja a Collegium minden bentlakó és bejáró aktív és passzív collegiumi jogviszonyú hallgatója, valamint bentlakó és bejáró seniorja.
+	\begin{enumerate}
+		\item Aktív collegiumi jogviszonya van annak a Collegistának, akinek aktív hallgatói jogviszonya van. Kivételt képeznek ez alól a külföldi részképzés, szakmai gyakorlat vagy továbbképzés keretében külföldön tartózkodók. Az ő collegiumi jogviszonyuk passzív.
+	\end{enumerate}
 	\item A CHÖK egyéb, nem kari szervezetbe tartozó szervezeti egység. Nem jogi személy, azonban megilletik a jogszabályban, az egyetemi szabályzatokban és a Collegium szabályzataiban megállapított jogok, és terhelik a kötelezettségek.
-	\item A CHÖK a Collegium érdekképviseletét és érdekvédelmét látja el, dönt a jelen Szabályzatban ráruházott személyi és egyéb kérdésekben, gyakorolja az ELTE és a Collegium Szervezeti és Működési Szabályzata (ELTE Szervezeti és Működési Szabályzat I. 4/g. melléklete, továbbiakban: SzMSz) által a CHÖK-re ruházott döntési, javaslattételi, véleményező és ellenőrző jogköröket, részt vesz a hallgatók ügyeinek intézésében és mindezeken kívül az Önkormányzat céljaival összeegyeztethető egyéb tevékenységet folytat. (vö. SzMSz 39. §)
-	\item A CHÖK tisztségviselőit és képviselőit a Collegium hallgatói választják meg jelen Alapszabályban meghatározott módon. Ennek során minden aktív státuszú hallgató választó, illetve választható a 14.§ figyelembevételével. A választójog általános, egyenlő és titkos.
-	\item A CHÖK tagjai közül tisztségviselőnek minősülnek a Választmány Elnöke, és Alelnökei.
+	\item A CHÖK a Collegium érdekképviseletét és érdekvédelmét látja el, dönt a jelen Szabályzatban ráruházott személyi és egyéb kérdésekben, gyakorolja az ELTE és a Collegium Szervezeti és Működési Szabályzata (ELTE Szervezeti és Működési Szabályzat I. 4/g. melléklete továbbiakban: SzMSz) által a CHÖK-re ruházott döntési, javaslattételi, véleményező és ellenőrző jogköröket, részt vesz a hallgatók ügyeinek intézésében és mindezeken kívül az Önkormányzat céljaival összeegyeztethető egyéb tevékenységet folytat. (vö. SzMSz 44. §)
+	\item A CHÖK tisztségviselőit és képviselőit a Collegium hallgatói választják meg jelen Alapszabályban meghatározott módon. Ennek során minden aktív collegiumi státuszú hallgató választó, illetve választható a 17.§ figyelembevételével. A választójog általános, egyenlő és a szavazás titkos.
+	\begin{enumerate}
+		\item A passzív collegiumi státuszú hallgatók a jelen szabályzatban meghatározott tisztségekre választhatók, ám ők sosem választók. Esetükben a 17.§ rendelkezései ugyanúgy érvényesek.
+	\end{enumerate}
+	\item A CHÖK tagjai közül tisztségviselőnek minősül a Választmány összes tagja.
+	\item A CHÖK minden tagjának lehetősége van a CHÖK tagjaként végzett közösségi tevékenységét a Collegium adminisztratív rendszerében vezetni. Ezeket a ELTE Eötvös József Collegium Oktatási, Tanulmányi Szabályzat és Követelményrendszerében (a továbbiakban: CTSzK) foglalt átlagkövetelmény nem teljesítése esetén a választmányi elnök a Collegium Tanári Karának bemutatja, amely ez alapján ajánlhatja az igazgatónak a collegiumi státusz megtartását.
+	\item A CHÖK a CTSzK-ban rögzített hivatalos adminisztrációs felületét használja adminisztációs célokból.
+	\begin{enumerate}
+		\item Amennyiben a CTSzK nem rögzít ilyet, a CHÖK hivatalos adminisztrációs felülete az Urán rendszere (https://uran.eotvos.elte.hu).
+	\end{enumerate}
+	\item A CHÖK hivatalos kommunikációs csatornái megegyeznek az CTSzK-ban rögzítettekkel
+	\begin{enumerate}
+		\item Amennyiben a CTSzK nem rögzít ilyet, a CHÖK hivatalos csatornái:
+		\begin{enumerate}
+			\item a membraCollegii levelezőlista,
+			\item az Urán adminisztrációs rendszeren keresztül kapott levél.
+		\end{enumerate}
+	\end{enumerate}
 	
 \end{enumerate}
 
@@ -38,15 +58,15 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 		\item A kari és egyetemi hallgatói önkormányzatokkal együttműködve ellátja a Collegium hallgatóinak érdekképviseletét valamennyi őket érintő kérdésben,
 		\item együttműködik az országos és egyetemi szakkollégiumi hallgatói szervezetekkel,
 		\item egyéb külügyekben képviseli a Collegium hallgatóinak érdekeit,
-		\item részt vesz a felvételi bizottságok munkájában, (vö. a Collegium Oktatási, Tanulmányi Szabályzata és Követelményrendszere, továbbiakban CTSZK 2§ 11-14.) a tudományos és szakmai diákkörök szervezésében;
-		\item kialakítja saját szervezeti és működési rendjét, és dönt a jelen Alapszabályban és az SzMSz-ben ráruházott személyi és egyéb kérdésekben;
+		\item részt vesz a felvételi bizottságok munkájában, (vö. CTSzK 3.§ 13, 16-18.) a tudományos és szakmai diákkörök szervezésében;
+		\item kialakítja saját szervezeti és működési rendjét, és dönt a jelen Alapszabályban, az SzMSz-ben és a CTSzK-ban ráruházott személyi és egyéb kérdésekben;
 		\item intézi és segíti a hallgatók Collegiummal kapcsolatos ügyeit, valamint segíti a Collegiumon kívüli tevékenységüket,
 		\item folyamatosan tájékoztatja a hallgatókat a CHÖK tevékenységéről, a Collegium életével kapcsolatos kérdésekről,
-		\item támogatja a hallgatók szakmai és egyéb közösségi tevékenységét, a hallgatói kezdeményezéseket képviseli és megvalósítja.
+		\item támogatja a Collegium hallgatóinak szakmai és egyéb közösségi tevékenységét, a Collegium hallgatóinak kezdeményezéseit képviseli és megvalósítja.
 	\end{enumerate}
 	\item A CHÖK egyetértést gyakorol:
 	\begin{enumerate}
-		\item az SzMSz elfogadásakor, illetve módosításakor;
+		\item a CTSzK és az SzMSz elfogadásakor, illetve módosításakor;
 		\item a Collegiumban működő jóléti, kulturális, sport célú ingatlanok és intézmények, szervezeti egységek, helyiségek rendeltetésszerű használatának megváltoztatásakor, megszüntetésekor és hasznosításával kapcsolatban;
 		\item a hallgatói célú pénzeszközök felhasználásában;
 		\item a hallgatói fegyelmi és kártérítési szabályzat elfogadásakor, módosításakor;
@@ -62,9 +82,12 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 	\item A CHÖK tevékenységét a következő szervek irányítják és ellenőrzik:
 	\begin{enumerate}
 		\item A CHÖK Közgyűlése (továbbiakban: Közgyűlés),
-		\item A CHÖK Közgyűlése által választott Választmány,
-		\item A CHÖK Közgyűlése által választott kuratóriumi diáktagok.
-	\end{enumerate}	
+		\item A Közgyűlés által választott Választmány (továbbiakban: Választmány),
+		\item A Közgyűlés által választott Kuratóriumi Diáktagok (továbbiakban: Kuratóriumi Diáktagok).
+		\item A Közgyűlés által választott Titkár (továbbiakban: Titkár).
+		\item A Közgyűlés által választott Ellenőrző Bizottság (továbbiakban: Ellenőrző Bizottság).
+	\end{enumerate}
+	\item A CHÖK további választott képviselői az Etikai Biztosok.
 \end{enumerate}
 
 
@@ -76,11 +99,12 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 	\begin{enumerate}
 		\item a Választmány megválasztása, beszámoltatása, felmentése,
 		\item a CHÖK Alapszabályának megalkotása, módosítása,
-		\item az SZMSZ, a CTSZK és a Collegium Házirendjének módosításával kapcsolatos javaslattételi és véleményezési jogának gyakorlása (vö. SzMSz 38. § (a)),
+		\item az SzMSz, a CTSzK és a Collegium Házirendjének módosításával kapcsolatos javaslattételi és véleményezési jogának gyakorlása (vö. SzMSz 43. § (a)),
 		\item a collegiumi igazgató kinevezésének és felmentésének véleményezése,
 		\item a Collegium fejlesztési tervének véleményezése,
-		\item a Kuratórium diáktagjainak választása (vö. SzMSz 15. §),
-		\item valamint döntéshozatal minden olyan ügyben, amelyet jelen Szabályzat, valamint bármely egyetemi szabályzat a Közgyűlés kizárólagos hatáskörébe utal.
+		\item a Kuratórium diáktagjainak megválasztása (vö. SzMSz 43. § (c)),
+		\item a Titkár és az Etikai Biztosok megválasztása, felmentése,
+		\item döntéshozatal minden olyan ügyben, amelyet jelen Szabályzat, valamint bármely egyetemi szabályzat a Közgyűlés kizárólagos hatáskörébe utal.
 	\end{enumerate}
 \end{enumerate}
 
@@ -89,46 +113,48 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 
 \begin{enumerate}
 	\item A Közgyűlés tagja a CHÖK valamennyi tagja.
-	\item Tanácskozási joggal az választmányi elnök által meghívott személyek. Javasolt meghívni az ELTE BTK, IK, TÁTK és TTK hallgatói önkormányzatának képviselőit, az ELTE EHÖK és KolHÖK elnökét, a Baráti Kör elnökét, a Tanári Kar tagjait, a Collegium igazgatóját és a Collegium gondnokát.
+	\item Tanácskozási joggal a választmányi elnök által meghívott személyek. Javasolt meghívni az ELTE EHÖK és KolHÖK elnökét, a Baráti Kör elnökét, a Tanári Kar tagjait, a Collegium igazgatóját és a Collegium gondnokát.
 \end{enumerate}
 
 \section{A Közgyűlés működése}
 
 \begin{enumerate}
-	\item A Közgyűlés üléseit a választmányi elnök, akadályoztatása esetén a választmányi alelnökök hívhatják össze és vezetik le.
-	\item A Közgyűlést a választmányi elnök nyitja meg és vezeti le.
+	\item A Közgyűlés üléseit a választmányi elnök, akadályoztatása esetén a választmányi alelnökök, a Választmány mandátumának félévközi megszűnése esetén a Titkár hívhatják össze, és vezetik le.
+	\item A Közgyűlést a választmányi elnök, nyitja meg és vezeti le.
 	\item A Közgyűlést a választmányi elnök indokolt esetben, legfeljebb egy alkalommal elnapolhatja. Az elnapolt Közgyűlés időpontja legkésőbb az eredeti után egy héttel lehet.
 	\item A Közgyűlést szemeszterenként legalább egyszer a választmányi elnök köteles összehívni.
-	\item A Közgyűlést 20 collegistának vagy a Collegium igazgatójának a Választmányhoz vagy a választmányi elnökhöz a cél megjelölésével írásban benyújtott indítványára legkésőbb tíz napon belül össze kell hívni. Amennyiben az összehívás tíz napon belül nem történik meg, akkor a kezdeményezők önállóan is összehívhatják a Közgyűlést.
+	\item A Közgyűlést 20 collegistának vagy a Collegium igazgatójának a Választmányhoz vagy a választmányi elnökhöz a cél megjelölésével írásban benyújtott indítványára legkésőbb tíz napon belül össze kell hívni. Amennyiben az összehívás tíz napon belül nem történik meg, akkor a kezdeményezők önállóan is összehívhatják a Közgyűlést, amelyet ebben az esetben a kezdeményezők által kijelölt személy nyit meg és vezet le.
+	\item Közgyűlést a 10.§ (2) pontjának megfelelően az Ellenőrző Bizottság összehívhat, melynek egyedüli jogkörét a 10.§ (2) d. v. 1. pontban leírtak képzik.
 	\item A Közgyűlés ülései az összehívás szempontjából minősülhetnek rendesnek és rendkívülinek.
 	\begin{enumerate}
 		\item A rendes Közgyűlés helyét, idejét és napirendjét a rendes Közgyűlést megelőzően legalább hét nappal közölni kell a tagokkal és a meghívottakkal.
-		\item Sürgős ügyek megtárgyalására rendkívüli Közgyűlés hívható össze. A rendkívüli ülés helyét, idejét és napirendjét a rendkívüli Közgyűlést megelőzően legalább két nappal közölni kell a tagokkal és a meghívottakkal. A rendkívüli Közgyűlés nem dönthet a 4. § (2) a., b., c., d. pontokban felsorolt kérdésekről.
+		\item Sürgős ügyek megtárgyalására rendkívüli Közgyűlés hívható össze. A rendkívüli ülés helyét, idejét és napirendjét a rendkívüli Közgyűlést megelőzően legalább két nappal közölni kell a tagokkal és a meghívottakkal. A rendkívüli Közgyűlés nem dönthet a 4.§ (2) a., b., c., d. pontokban felsorolt kérdésekről.
 	\end{enumerate}
 	\item A Közgyűlés akkor határozatképes, ha a tagok több mint fele jelen van.
 	\begin{enumerate}
-		\item A határozathozatalhoz a jelenlevő tagok egyszerű többségének egybehangzó szavazata szükséges, kivéve a 4. § (2) b. pontja, amelyben a jelenlevők kétharmadának egybehangzó szavazata szükséges.
-		\item Titkos szavazásra kerül sor valamennyi személyi kérdésben, illetve ha azt a Közgyűlés legalább öt tagja kéri.
+		\item A határozathozatalhoz a jelenlevő tagok egyszerű többségének szavazata szükséges, kivéve a 4.§ (2) b. pontja, amelyben a jelenlevők kétharmadának egybehangzó szavazata szükséges.
+		\item Titkos szavazásra kerül sor valamennyi személyi kérdésben, illetve amennyiben azt a Közgyűlés legalább öt tagja kéri.
 		\item Amennyiben az összehívott Közgyűlés nem határozatképes, akkor az ülést nyolc napon belül változatlan napirenddel össze kell hívni.
 		\item A megismételt közgyűlés határozatképes, ha a tagok több mint negyede jelen van.
 	\end{enumerate}
-	\item Titkos szavazás esetén a Közgyűlés jelenlévő tagjai közül háromtagú Szavazatszedő és -számláló Bizottságot (továbbiakban: SZB) kell választani, melynek nem lehet tagja a Választmány tagja, műhelytitkár és kuratóriumi diáktag. A szavazás eredményéről a SZB írásos jelentést készít és ezt három munkanapon belül nyilvánosságra hozza. Ezt a jelentést csatolni kell a Közgyűlésről vezetett jegyzőkönyvhöz.
+	\item Titkos szavazás esetén a Közgyűlés jelenlévő tagjai közül háromtagú Szavazatszedő és - számláló Bizottságot (továbbiakban: SZB) kell választani, melynek nem lehet tagja jelölt, a Választmány tagja, műhelytitkár és Kuratóriumi Diáktag. A szavazás eredményéről a SZB írásos jelentést készít és ezt haladéktalanul nyilvánosságra hozza. Ezt a jelentést csatolni kell a Közgyűlésről vezetett jegyzőkönyvhöz.
 	\item A Közgyűlés valamennyi tagját indítványozási, véleménynyilvánítási, javaslattételi és szavazati jog illeti meg. A Közgyűlés minden tagja egy, át nem ruházható szavazattal rendelkezik.
 	\item A Közgyűlés üléseiről jegyzőkönyvet kell készíteni, amely tartalmazza az ülés lefolyásának lényegesebb mozzanatait, továbbá a napirendi pontokkal és az indítványokkal kapcsolatos határozatokat, különös tekintettel a szavazásra feltett kérdésekben elhangzott kisebbségi véleményekre és szavazati arányokra.
 	\begin{enumerate}
 		\item A jegyzőkönyv elkészítéséről a Titkár gondoskodik, és azt az ülést levezető elnökkel, a CHÖK egy, az elnök által felkért tagjával együtt aláírásával hitelesíti (kivéve a b. pontban meghatározott esetben).
-		\item A Titkár akadályoztatása esetén a levezető elnök a Közgyűlés tagjai közül jegyzőkönyvvezetőt kér fel.
+		\item A Titkár akadályoztatása esetén a levezető elnök a Közgyűlés tagjai közül jegyzőkönyvvezetőt kér fel, aki a 6.§ (11) a. pontja szerint jár el.
 		\item A jegyzőkönyvet 15 napon belül nyilvánosságra kell hozni.
 		\item A jegyzőkönyv mellé minden esetben csatolni kell a jelenléti ívet is.
 	\end{enumerate}
-	\item A Közgyűlés ülései a Collegium valamennyi tagja számára nyilvánosak, de a levezető elnök valamely tag kérésére, egy napirendi pont megvitatására – a Közgyűlés által egyszerű többséggel hozott döntéssel – zárt ülést is elrendelhet.
+	\item A Közgyűlés ülései a Collegium valamennyi tagja számára nyilvánosak, de a levezető elnök valamely tag kérésére, egy napirendi pont megvitatására -- a Közgyűlés által egyszerű többséggel hozott döntéssel -- zárt ülést is elrendelhet.
 	\begin{enumerate}
 		\item Zárt ülés esetén mindenkinek, aki nem tagja a CHÖK-nek, el kell hagynia a termet.
 		\item Zárt ülés csak és kizárólag azt a napirendi pontot tárgyalhatja, amely miatt elrendelték.
 		\item A napirendi pont lezárása után a zárt ülést a levezető elnöknek föl kell függesztenie, és a Közgyűlés ismét nyílt üléssé alakul.
 	\end{enumerate}
 	\item Bármely tag javaslatára a Közgyűlés egyszerű szótöbbséggel tanácskozási jogot szavazhat meg a jelenlévő személyeknek.
-	\item A Közgyűlés véleményezi az igazgatói pályázatokat (vö. SzMSz 40. §).
+	\item A Közgyűlés véleményezi az igazgatói pályázatokat (vö. SzMSz 43. § (b)).
+	\item A Választmány beszámolójáról a Közgyűlés tisztségviselőnként szavaz.
 \end{enumerate}
 
 
@@ -140,119 +166,151 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 	\begin{enumerate}
 		\item irányítja a CHÖK tevékenységét a Közgyűlés ülései közötti időszakokban,
 		\item dönt minden olyan kérdésben, amelyet a Közgyűlés, egyetemi vagy önkormányzati szabályzat rá átruházott vagy részére megállapított, illetve amely nem tartozik a Közgyűlés kizárólagos hatáskörébe,
-		\item gondoskodik a jelen Szabályzatban foglaltak, az SzMSz, a Tanulmányi Szabályzat, a CHÖK működési szabályzata, a Házirend, valamint a Közgyűlés határozatainak végrehajtásáról és betartásáról,
-		\item folyamatos és szervezett kapcsolatot tart fenn más hallgatói szervezetekkel, kiemelten fontos ezek közül az ELTE EHÖK, BTK HÖK, IK HÖK, a TÁTK HÖK, TTK HÖK és az ELTE KolHÖK, a Szakkollégiumi Mozgalom, valamint ezek bizottságai, illetve a szakkollégiumok és testvérkollégiumok.
+		\item gondoskodik a jelen Szabályzatban foglaltak, az SzMSz, a CTSzK, a CHÖK működési szabályzata, a Házirend, valamint a Közgyűlés határozatainak végrehajtásáról és betartásáról,
+		\item folyamatos és szervezett kapcsolatot tart fenn más hallgatói szervezetekkel, kiemelten fontos ezek közül az ELTE EHÖK, a BTK HÖK, a GTK HÖK, az IK HÖK, a TÁTK HÖK, a TTK HÖK és az ELTE KolHÖK, a Szakkollégiumi Mozgalom, valamint ezek bizottságai, illetve a szakkollégiumok és testvérkollégiumok.
 		\item kezdeményezi, megtervezi, irányítja és ellenőrzi az egyes Bizottságok működését.
 	\end{enumerate}
-	\item A Választmány munkájáról a Választmány elnöke és a Gazdasági Bizottság elnöke minden nem rendkívüli Közgyűlésen beszámol.
+	\item A Választmány tagjaként végzett munkájáról a Választmány összes tagja minden rendes  Közgyűlés előtt írásban beszámol. A beszámolót a tagságnak a CHÖK hivatalos kommunikációs csatornáján keresztül küldi ki, emellett külön eljuttatja az Ellenőrző Bizottságnak. A kiküldésnek a Közgyűlés előtt legkésőbb 5 nappal meg kell történnie.
 \end{enumerate}
 
 
 \section{A Választmány tagjai}
 
 \begin{enumerate}
-	\item A Választmány kilenc rendes tagból áll:
+	\item A Választmány hét rendes tagból áll:
 	\begin{enumerate}
 		\item a Választmány elnöke,
-		\item a Választmány kettő alelnöke,
-		\item a Gazdasági Bizottság elnöke,
-		\item a Kommunikációs Bizottság elnöke,
-		\item a Közösségi Bizottság elnöke,
-		\item a Kulturális Bizottság elnöke,
-		\item a Sportbizottság elnöke,
-		\item a Tudományos Bizottság elnöke.
+		\item a Választmány gazdasági alelnöke,
+		\item a Választmány szakmai alelnöke
+        \item a Kommunikációs Bizottság elnöke,
+        \item a Közösségi Bizottság elnöke,
+        \item a Kulturális Bizottság elnöke,
+        \item a Sportbizottság elnöke.
 	\end{enumerate}
-	\item A Választmány kötelezően meghívott tagja a Titkár és a Tanácsadó Testület tagjai és a kuratóriumi diáktagok.
 	\item A Választmány mandátuma:
 	\begin{enumerate}
-		\item A Választmány mandátuma az egy évig tartó megbízatása lejártáig,  illetve a Választmány elnökének vagy alelnökeinek lemondásáig vagy a Közgyűlés által történő felmentéséig tart. Egy éves megbízatás esetén a Választmány mandátuma
+		\item A Választmány mandátuma az egy évig tartó megbízatása lejártáig vagy egyéb úton történő megszűnéséig tart. Ezeket a 8.§ (2) b-e. pontja részletezi. Egy éves megbízatás esetén a Választmány mandátuma
 		\begin{enumerate}
-			\item tavaszi félévben történő megválasztás esetén a rákövetkező évbeli március 1-ig érvényés;
-			\item őszi félévben történő megválasztás esetén a rákövetkező évbeli október 1-ig érvényes
+			\item tavaszi félévben történő megválasztás esetén a rákövetkező évbeli március 1-ig érvényes;
+			\item őszi félévben történő megválasztás esetén a rákövetkező évbeli október 1-ig érvényes.
 		\end{enumerate}
-		érvényes.
-		\item A Választmány elnökének és alelnökeinek mandátuma megszűnik, amennyiben
+		\item A Választmány tagjainak mandátuma megszűnik, amennyiben
 		\begin{enumerate}
-			\item az egy éves megbízatása lejár,
+			\item az egyéves megbízatása lejár,
 			\item lemond vagy a Közgyűlés felmenti.
 		\end{enumerate}
-		\item A bizottsági elnökök mandátuma megszűnik, amennyiben
+		\item A Választmány megbízatása véget ér bármely tagjának lemondása, felmentése esetén. Kivételt képez ezalól a 8.§ (2) e. pontja.
+		\item Amennyiben a Választmány megbízatása véget ér két Közgyűlés között, a Titkár két héten belülre rendes Közgyűlést hív össze, amely időpontjáig az előző Választmány ügyvezető Választmányként működik.
 		\begin{enumerate}
-			\item az egyéves megbízatásuk lejár,
-			\item lemond vagy a választmányi elnök a Választmány egyetértésével felmenti,
-			\item a választmányi elnök vagy alelnökök mandátumának megszűnésével
+			\item Amennyiben a Választmány megbízatása a Közgyűlés felmentése nyomán ér véget, a kiírt Közgyűlés időponjáig a Választmány feladatait a Titkár, és az általa kijelölt ideiglenes tisztségviselők veszik át.
 		\end{enumerate}
-		\item Amennyiben a Választmány megbízatása véget ér két Közgyűlés között, két héten belül rendes Közgyűlést kell összehívni, amely időpontjáig az előző Választmány ügyvezető Választmányként működik.
+		\item Amennyiben egy bizottsági elnök mond le a tisztségéről, abban az esetben a Választmány elnöke a posztra ideiglenes bizottsági elnököt javasolhat, amelyet a Választmány egyszerű többséggel szavaz meg.
+		\begin{enumerate}
+			\item A bizottság elnökének lemondásáról a választmányi elnök köteles a tagságot 24 órán belül értesíteni. A CHÖK bármely tagjának 3 napon belüli kérése esetén a választmány megbízatása megszűnik, ezzel együtt a választmányi elnök köteles a kérés beérkezésétől számított 24 órán belül a 6.§ (7) a. pontja szerint rendes Közgyűlést összehívni.
+		\end{enumerate}
 	\end{enumerate}
 	\item A Választmány elnöke
 	\begin{enumerate}	
-		\item a Közgyűlés és a Választmány döntéseinek megfelelően, a hatályos jogszabályok, egyetemi szabályzatok és a Collegium szabályzatainak rendelkezései alapján irányítja, vezeti és egy személyben képviseli a CHÖK-öt,
-		\item irányítja a Választmány tevékenységét,
-		\item folyamatos munkakapcsolatot tart fenn a Collegium igazgatójával és más tisztségviselőivel,
-		\item felel a Választmány és a Közgyűlés üléseinek előkészítéséért, 
-		\item vezeti a Közgyűlés és a Választmány üléseit,
-		\item tisztsége alapján képviseli a CHÖK-öt a 7. § 2. d.-ben meghatározott fórumokon,
+		\item a Közgyűlés és a Választmány döntéseinek megfelelően, a hatályos jogszabályok, egyetemi szabályzatok és a Collegium szabályzatainak rendelkezései alapján irányítja, vezeti és egy személyben képviseli a CHÖK-öt.
+		\item irányítja a Választmány tevékenységét.
+		\item folyamatos munkakapcsolatot tart fenn a Collegium igazgatójával és más tisztségviselőivel.
+		\item részt vesz a Tanári Kar ülésein (vö. SzMSz 30. § (2)).
 		\begin{enumerate}
-			\item Akadályoztatása esetén hivatalos meghatalmazással delegálhatja a Választmány tagjait. Kívánatos, hogy az alelnököket, illetve az illetékes bizottságok elnökeit delegálja egyes szervezetek üléseire.
+			\item Itt köteles az átlagkritériumnak nem megfelelő collegista közösségi tevékenységéről a Tanári Kart tájékoztatni (vö. CTSzK 8. § (4) b) iii.).
+            \item Itt köteles a Közgyűlést kétszer egymás után igazolatlanul elmulasztók névsoráról a Tanári Kart tájékoztatni.
 		\end{enumerate}
-		\item feladat- és hatáskörét átruházhatja a Választmány tagjaira egyedi megbízással, a megbízott az elvégzett munkáról a Választmánynak beszámolni köteles,
-		\item felügyeli a Tudományos és a Gazdasági Bizottság működését,
-		\item joga van rendkívüli feladatok ellátása miatt eseti (ad hoc) bizottság létrehozására,
-		\item a Választmány delegáltja a KolHÖK üléseire.
+		\item részt vesz a Kuratórium ülésein (vö. SzMSz 25. §).
+        \item felel a Választmány és a Közgyűlés üléseinek előkészítéséért.
+        \item vezeti a Közgyűlés és a Választmány üléseit.
+        \item tisztsége alapján képviseli a CHÖK-öt a 7. § 2. d.-ben meghatározott fórumokon.
+		\begin{enumerate}
+            \item Akadályoztatása esetén hivatalos meghatalmazással delegálhatja a Választmány tagjait. Kívánatos, hogy az alelnököket, illetve az illetékes bizottságok elnökeit delegálja egyes szervezetek üléseire.
+		\end{enumerate}
+		\item minden félév eleji Közgyűlésen az elmúlt félévben végzett munkájáról prenzentációval beszámolni köteles.
+        \item felel a Collegium mindenkori első évfolyama számára tartott bevezető kurzus tematikájának kialakításáért és sikeres lebonyolításáért.
+        \item feladat- és hatáskörét átruházhatja a Választmány tagjaira egyedi megbízással, a megbízott az elvégzett munkáról a Választmánynak beszámolni köteles.
+        \item joga van rendkívüli, tehát más bizottság körébe nem tartozó feladatok ellátására eseti (ad hoc) bizottság létrehozására.
+        \item ellátja a 16. § (4) pontban meghatározott, az Etikai Biztosokhoz kapcsolódó további feladatokat, a Választmányi ülés elé tárja a Biztosok beszámolóit.
 	\end{enumerate}
-	\item A Választmány alelnökei
-		\begin{enumerate}
-		\item a választmányi elnök távollétében a választmányi elnök feladatait valamely alelnök látja el.
-		\item Az alelnökök felügyelik és koordinálják a Kommunikációs, Közösségi, Kulturális és Sportbizottságok működését.
-		\item Az alelnökök figyelemmel kísérik a Választmány és a 7. § 2. b.-ben meghatározott fórumok munkáját, kapcsolatot tart fent a Collegium és jelen szervek között, illetve szükség esetén elsősorban ők helyettesítik az elnököt ezen fórumokon.
-		\item Az alelnökök az elnök akadályoztatása esetén a Választmány delegáltja a KolHÖK küldöttgyűlésébe.
-		\item A mindenkori alelnökök az aktuális feladatokat egymás közötti kölcsönös megegyezés alapján osztják fel.
-		\end{enumerate}
-	\item A bizottsági elnök
-		\begin{enumerate}
-		\item a CHÖK szakmai és közösségi feladatait látja el a választmányi elnök irányítása és felügyelete mellett, utasításai alapján,
-		\item a választmányi elnök nevezi ki a Collegium hallgatói közül,
-		\item feladata:
-			\begin{enumerate}
-			\item segíti a választmányi elnök munkáját az illetékes szakterületen;
-			\item irányítja az adott szakterület, illetve szaktestület munkáját;
-			\item tevékenységéről havi rendszerességgel szóban köteles beszámolni a választmányi elnöknek a választmányi ülésen;
-			\item tevékenységéről félévente írásban beszámol a Közgyűlésnek;
-			\item szemeszterenként legalább kétszer összehívja és vezeti az adott szaktestület ülését, felelős a szaktestületi döntések végrehajtásáért;
-			\item képviseli az érintett szaktestületet, a szaktestület munkájáról beszámol a Választmánynak és a Közgyűlésnek;
-			\item elkészíti a feladatkörébe tartozó ügyek szabályzattervezetét, módosítását;
-			\item folyamatosan kapcsolatot tart a szakterületén érdekelt más kari és egyetemi hallgatói önkormányzati tisztségviselőkkel, valamint collegiumi és egyetemi dolgozókkal;
-			\item ellátja mindazokat a feladatokat, amit jelen Alapszabály vagy a választmányi elnök hatáskörébe utal.
-			\end{enumerate}
-		\end{enumerate}
-	\item A bizottságok működése
-		\begin{enumerate}
-		\item A bizottságok a 8. § (8) – (14) pontban meghatározott feladatukat ellátják.
-		\item A bizottsági üléseken mandátummal rendelkezik a bizottság elnöke és a bizottság tagjai, akiket a bizottság elnöke vagy valamely alelnök vagy az elnök javaslatára a Választmány elnöke nevez ki. 
-		\item Minden bizottság ülésére kötelezően meghívott a Választmány elnöke és az alelnökök, akik tanácskozási joggal lehetnek jelen.
-		\item A bizottsági üléseken tanácskozási joggal jelen lehetnek a CHÖK tagjai.
-		\item A bizottság üléseiről jegyzőkönyv készül, amelyet a jegyzőkönyvvezető, a bizottság elnöke és egy bizottsági tag aláírásával hitelesít, majd a Titkár iktat.
-		\item A bizottsági tagok száma a bizottsági elnökön kívül legalább két fő. 
-			\begin{enumerate}
-			\item Amennyiben létszámuk kettő alá csökken, a megüresedett helyekre a bizottság elnöke, a választmányi elnök vagy valamely alelnök által javasolt személyeket a Választmány elnöke nevezi ki.
-			\end{enumerate}
-		\end{enumerate}
-	\item A Gazdasági Bizottság
+
+	\item A Választmány szakmai alelnöke (továbbiakban: szakmai alelnök)
 	\begin{enumerate}
-		\item felelős a CHÖK szabályszerű pénz- és vagyonkezeléséért, valamint a Gazdálkodási és Vagyongazdálkodási szabályzat (ELTE Szervezeti és Működési Szabályzat I. 5. melléklet) betartásáért,
-		\item kezeli a Választmány vagyonát,
-		\item félévente beszámolót készít, amelyet a Közgyűlésen ismertet a CHÖK tagjaival,
-		\item felel a nagyobb pályázatok megírásáért és elszámolásáért,
-		\item felügyeli a Választmány és a bizottságok által írt pályázatok elkészítését, elszámolását,
-		\item szükség esetén segítséget nyújt az elkészítésben, elszámolásban,
-		\item elkészíti a Választmány szemeszterenkénti költségvetési tervét,
-		\item segít a többi Bizottságnak a programok költségvetési tervét elkészíteni, illetve felügyeli, ellenőrzi és jóváhagyja ezeket,
-		\item új pénzforrásokat, pályázati forrásokat és szponzorációs lehetőségeket keres,
-		\item iktatja a pénzügyeket, ezáltal transzparenssé téve a Választmány pénzgazdálkodását,
-		\item felel a pályázatfigyelésért, illetve a Bizottságok ilyen irányú tájékoztatásáért,
-		\item kapcsolatot tart az ELTE Karrierközponttal, a Pályázati és Innovációs Központtal, lehetőség szerint igényeknek megfelelő képzéseket szervez a Collegiumba,
-		\item kapcsolatot tart az Igazgatóval a Collegium gazdálkodásával kapcsolatos kérdésekben, valamint a nagyobb pályázatok ügyében.
+		\item felel az SzMSz 52. § (1) e) pontjában meghatározott módon választott műhelytitkárokkal való kommunikációért, koordinálja és ellenőrzi tevékenységüket.
+		\item megszervezi a Műhelytitkári Fórum üléseit, melynek tagjai a műhelyek által választott műhelytitkárok és műhelytitkár-helyettesek, elnöke a szakmai alelnök. Kötelező meghívottja a választmányi elnök.
+		\begin{enumerate}
+			\item A Műhelytitkári Fórumot félévente legalább 2 alkalommal köteles összehívni.
+			\item A műhelytitkárok akadályoztatásuk esetén a Műhelytitkári Fórum üléseire írásos meghatalmazással műhelyükből egy főt delegálhatnak.
+			\item A Műhelytitkári Fórum felületet biztosít a műhelytitkároknak a műhelyben fellépő belső problémák jelzésére. Amennyiben szükséges, a szakmai alelnök közvetíti ezeket az igazgató felé.
 		\end{enumerate}
+		\item c. részt vesz a Tanári Kar ülésein (vö. SzMSz 30. § (2)).
+		\item d. felelős a Collegium reprezentatív felületein (pl. műhelyhonlapok) a műhelyekkel kapcsolatos információk frissítéséért.
+		\begin{enumerate}
+			\item 	i. a műhelyhonlapok frissítéséhez a Collegium rendszergazdáival való egyeztetés után a műhelytitkároknak sablont bocsájt rendelkezésre.
+		\end{enumerate}
+		\item e. kapcsolatot tart az ELTE EDÖK-kel és az ELTE EHÖK, BTK, GTK, IK, TÁTK, TTK Tudományos Bizottságaival.
+		\item felelős a collegiumi szintű szakmai programok megszervezéséért, az azokkal kapcsolatos elvi döntések meghozataláért, illetve az azokkal kapcsolatos kiadványok szerkesztésének megszervezéséért, úgy mint
+		\begin{enumerate}
+			\item 	i. Eötvös Konferencia,
+			\item 	ii. Eötvös József Tehetséggondozó Tábor.
+		\end{enumerate}
+		\item az egyes műhelyek szabályzatmódosításában véleményezési joga van.
+        \item a műhelytitkárok igényei szerint felel a műhelyeket érintő problémák megoldásáért, a műhelyprogramok hirdetéséért.
+        \item joga az Eötvös Konferenica szervezésére főszervező(ke)t felkérni. A Konferencia sikeres lebonyolításának felelőssége továbbra is a szakmai alelnököt terheli.
+		\begin{enumerate}
+            \item A főszervező(k) kötelező meghívottja(i) a Választmány üléseinek.
+            \item A főszervező(k) összehívhat(nak) megbeszéléseket az elvégzendő feladatokkal kapcsolatban.
+		\end{enumerate}
+	\end{enumerate}
+	\item A Választmány gazdasági alelnöke (továbbiakban: gazdasági alelnök)
+	\begin{enumerate}
+		\item felelős a CHÖK szabályszerű pénz- és vagyonkezeléséért, valamint a Gazdálkodási és Vagyongazdálkodási szabályzat (ELTE Szervezeti és Működési Szabályzat I. 5. melléklet) betartásáért.
+		\item kezeli a Választmány vagyonát.
+		\item minden félév eleji Közgyűlésre költségvetési tervet készít az elkövetkező félévről, amelynek megvalósulásáról az azt követő Közgyűlésen prenzentációval beszámolni köteles.
+		\item felel a nagyobb pályázatok megírásáért és elszámolásáért.
+		\item felügyeli és segítséget nyújt a Választmány és a bizottságok által írt pályázatok elkészítésében, elszámolásában.
+		\item segít a többi bizottságnak a programok költségvetési tervét elkészíteni, illetve felügyeli, ellenőrzi és jóváhagyja ezeket.
+		\item új pénzforrásokat, pályázati forrásokat és szponzorációs lehetőségeket keres.
+		\item a Collegium adminisztratív felületén iktatja a pénzügyeket, ezáltal transzparenssé téve a Választmány pénzgazdálkodását.
+		\item kapcsolatot tart az igazgatóval a Collegium gazdálkodásával kapcsolatos kérdésekben, valamint a nagyobb pályázatok ügyében.
+	\end{enumerate}
+	\item A Választmány elnöksége az elnökből, a szakmai alelnökből és a gazdasági alelnökből áll.
+	\item A bizottsági elnök
+	\begin{enumerate}
+		\item a CHÖK közösségi feladatait látja el: az illetékes szakterületen bizottságot szervez és vezet.
+		\item megválasztása a Közgyűlésen az elnökséggel együtt történik.
+		\item feladata:
+		\begin{enumerate}
+			\item segíti a választmányi elnök munkáját az illetékes szakterületen.
+			\item irányítja az adott szakterületet, illetve az alá tartozó bizottság munkáját.
+			\item tevékenységéről havi rendszerességgel szóban köteles beszámolni a választmányi elnöknek a választmányi ülésen.
+			\item tevékenységéről félévente írásban beszámol a Közgyűlésnek.
+			\item szemeszterenként legalább kétszer összehívja és vezeti az adott bizottság ülését, felelős a bizottsági döntések végrehajtásáért.
+			\item képviseli az érintett bizottságot, munkájáról beszámol a Választmánynak és a Közgyűlésnek.
+			\item elkészíti a feladatkörébe tartozó ügyek szabályzattervezetét, módosítását.
+			\item folyamatosan kapcsolatot tart a szakterületén érdekelt más kari és egyetemi hallgatói önkormányzati tisztségviselőkkel, valamint collegiumi és egyetemi dolgozókkal.
+			\item ellátja mindazokat a feladatokat, amit jelen Alapszabály vagy a választmányi elnök hatáskörébe utal.
+		\end{enumerate}
+	\end{enumerate}
+\end{enumerate}
+
+\section{A bizottságok felépítése és működése}
+
+\begin{enumerate}
+	\item A bizottságok a 9. § (8) -- (11) pontban meghatározott feladatukat ellátják.
+	\item A bizottsági üléseken mandátummal rendelkezik a bizottság elnöke és a bizottság tagjai, akiket egyéni jelentkezés vagy felkérés alapján a bizottság elnöke bármely ülésen kinevezhet.
+	\begin{enumerate}
+		\item A kinevezést a Titkárnak iktatnia kell. Ajánlott, hogy ezt a Collegium adminisztratív felületén tegye.
+	\end{enumerate}
+	\item A bizottság tagjai közül a bizottság elnöke meghatározott feladatra referenst nevezhet ki, ennek megvalósulásáért a végső felelősséget továbbra is a bizottság elnöke viseli.
+	\begin{enumerate}
+		\item A referens meghatározott feladat szervezéséért és végrehajrásáért felel, erről köteles a Választmánynak beszámolni.
+		\item A referens a bizottság elnökéhez hasonlóan ülést hívhat össze, amelyen az rá ruházott tevékenységi körrel kapcsolatos feladatokat szervezi ki. A ülésekről jegyzőkönyv készül, amelyet a jegyzőkönyvvezető és a referens aláírásával hitelesít, majd a Titkár iktat.
+		\item A jelen szabályzat az egyes bizottságokhoz tartozó alpontokban leírt feladatkörökre ajánlja a referensi pozíciók létrehozását.
+	\end{enumerate}
+	\item Minden bizottság ülésére kötelezően meghívott a Választmány elnöke és az alelnökök, akik tanácskozási joggal lehetnek jelen.
+	\item A bizottsági üléseken tanácskozási joggal jelen lehetnek a CHÖK tagjai.
+	\item A bizottság üléseiről jegyzőkönyv készül, amelyet a jegyzőkönyvvezető, a bizottság elnöke és egy bizottsági tag aláírásával hitelesít, majd a Titkár iktat.
+	\item A bizottsági tagok száma a bizottsági elnökön kívül legalább két fő, amely minimumlétszám fenntartásáért a bizottság elnöke felel.
 	\item A Kommunikációs Bizottság
 	\begin{enumerate}
 		\item rendszeresen tájékoztatja a Collegiumot, a CHÖK tagjait a Választmány munkájáról,
@@ -261,80 +319,138 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 		\item felel a Választmány kiadványainak korrektúrázásáért,
 		\item moderálja a Választmány hatáskörébe tartozó levelezőlistákat és elektronikus felületeket,
 		\item további megjelenési és hirdetési felületeket keres,
-		\item a Választmánnyal egyeztetve kapcsolatot tart az ELTE BTK, IK, TÁTK és TTK kommunikációs bizottságaival, valamint más ELTE-s kommunikációs fórumokkal,
+		\item a Választmánnyal egyeztetve kapcsolatot tart az ELTE BTK, GTK, IK, TÁTK és TTK kommunikációs bizottságaival, valamint más ELTE-s kommunikációs fórumokkal,
 		\item továbbítja a Szakkollégiumi Mozgalom híreit a collegisták felé,
-		\item profiljába tartozó eszközökre, szolgáltatásokra pályázik.
+		\item esetében a jelen szabályzat a következő feladatkörökre ajánlja referens kinevezését:
+		\begin{enumerate}
+			\item Epistola Collegii szerkesztése,
+			\item közösségi felületek kezelése,
+			\item pályaválasztási eseményekre való kitelepülés,
+			\item plakátok készítése a többi bizottság, illetve a műhelyek programjaira.
+		\end{enumerate}
 	\end{enumerate}
 	\item A Közösségi Bizottság
 	\begin{enumerate}
-		\item felel a közösségi, gólya- és alumniprogramok, projektek megszervezéséért és lebonyolításáért,
-		\item a Collegium szakmai programjaira biztosítja a humán erőforrásokat és a szükséges feltételeket (étel, ital, promóciós termékek, kiadványok, ajándékok stb.),
-		\item együttműködik az önszerveződő közösségi körökkel, csoportosulásaival és segíti munkájukat,
-		\item profiljába tartozó rendezvényekre, eszközökre, szolgáltatásokra pályázik.
+		\item felel a közösségi, gólya- és alumniprogramok, projektek megszervezéséért és lebonyolításáért.
+		\item a Collegium szakmai programjaira biztosítja a humán erőforrásokat és a szükséges feltételeket.
+		\item együttműködik az önszerveződő közösségi körökkel, csoportosulásokkal, és segíti munkájukat.
+		\item esetében a jelen szabályzat a következő feladatkörökre ajánlja referens kinevezését:
+		\begin{enumerate}
+			\item A GóJabál és a Convivium megszervezése
+			\item A GóJahétvége megszervezése
+		\end{enumerate}
 	\end{enumerate}
 	\item A Kulturális Bizottság
 	\begin{enumerate}
-		\item segíti a Collegium kulturális körei, csoportosulásai munkáját,
-		\item igényfelmérés alapján kulturális programokat szervez,
+		\item segíti a Collegium kulturális körei, csoportosulásai munkáját. Többek között:
+		\begin{enumerate}
+			\item EKÉT,
+			\item D’Coeur,
+			\item Filmklub,
+			\item ÍróCör.
+		\end{enumerate}
+		\item igényfelmérés alapján kulturális programokat szervez.
+		\item feladata a többi bizottság által szervezett közösségi programokra igény esetén kulturális programok szervezésére.
 		\item profiljába tartozó rendezvényekre, eszközökre, szolgáltatásokra pályázik.
+		\item az önszerveződő körök vezetőivel aktív kapcsolatot tart.
+		\item esetében a jelen szabályzat a következő feladatkörökre ajánlja referens kinevezését:
+		\begin{enumerate}
+			\item Open Mic szervezése,
+			\item Filmklub szervezése.
+		\end{enumerate}
 	\end{enumerate}
 	\item A Sportbizottság
 	\begin{enumerate}
-		\item segíti a Collegiumban működő sportkörök munkáját, sportprogramokat szervez,
-		\item elősegíti az esélyegyenlőség megvalósulását,
-		\item tartja a kapcsolatot a profiljába tartozó szervezetekkel, egyesületekkel,
+		\item segíti a Collegiumban működő sportkörök munkáját, sportprogramokat szervez.
+		\item kapcsolatot tart más szakkollégiumok sportért felelős szervezetével.
 		\item a profiljába tartozó rendezvényekre, eszközökre, szolgáltatásokra pályázik.
+		\item esetében a jelen szabályzat a következő feladatkörökre ajánlja referens kinevezését:
+		\begin{enumerate}
+			\item a Collegiumban működő sportok/sportkörök fenntartására, amelyek pl. foci, röplabda, sakk stb.
+			\item az Eötvös Collegiumi Éjszakai Sportok programjainak megszervezése,
+			\item A Futóhónap megszervezése.
+		\end{enumerate}
 	\end{enumerate}
-	\item A Tudományos Bizottság
-	\begin{enumerate}
-		\item két szervből áll: a háromfős operatív szervből és a kiterjesztett bizottságból,
-		\item az operatív szerv tagjai: a bizottság elnöke és a két bizottsági tag,
-		\item az operatív szerv felel a kiterjesztett bizottság üléseinek előkészítéséért, a döntések, határozatoknak megfelelően a kivitelezésért, megszervezéséért; kapcsolatot tart az EDÖK-kel és az ELTE EHÖK, BTK, IK, TÁTK, TTK Tudományos Bizottságaival.
-		\item a kiterjesztett bizottság mandátummal rendelkező rendes tagjai a Collegium műhelyeinek választott titkárai, és a bizottság elnöke. A műhelytitkárok akadályoztatásuk esetén a kiterjesztett bizottsági ülésekre írásos meghatalmazással műhelyükből egy főt delegálhatnak.
-		\item az operatív szerv ülését és a kiterjesztett bizottsági ülést kéthavonta felváltva hívja össze a bizottság elnöke. A kiterjesztett bizottsági ülésen a bizottság elnöke és az operatív szerv egy tagja kötelezően részt vesz. A Választmány elnöke kötelezően meghívott.
-		\item felelős a collegiumi szintű szakmai programok megszervezéséért, az azokkal kapcsolatos elvi döntések meghozataláért,
-		\item az egyes műhelyek szabályzatmódosításában véleményezési joga van,
-		\item a műhelytitkárok igényei szerint felel a műhelyeket érintő problémák megoldásáért, a műhelyprogramok hirdetéséért.
-	\end{enumerate}
+\end{enumerate}
+
+\section{A Választmányt ellenőrző szervek és működésük}
+
+\begin{enumerate}
 	\item A Titkár
 	\begin{enumerate}
-		\item felügyeli a Választmány szabályszerű működését, ellenőrzi tagjainak tevékenységét,
+		\item felügyeli a Választmány szabályszerű működését, ellenőrzi tagjainak tevékenységét.
 		\begin{enumerate}
 			\item Amennyiben a Titkár szabálytalanságot észlelt, azt köteles az elnöknek jelenteni.
 			\item Amennyiben a szabálytalanság megismétlődik, illetve a Választmány nem mutat kellő igyekezetet annak javítására, a Titkár köteles a szabályszegést a Közgyűlésnek jelenteni.
 		\end{enumerate}
-		\item meghívottként részt vesz a Közgyűlésen, a Választmány és az egyes bizottságok ülésein, azokról jegyzőkönyvet készít,
-		\item akadályoztatása esetén a választmányi elnök vagy az adott bizottság elnöke jegyzőkönyvvezetőt kér fel,
+		\item meghívottként részt vesz a Közgyűlésen, a Választmány és az egyes bizottságok ülésein, azokról jegyzőkönyvet készít.
+		\item akadályoztatása esetén a választmányi elnök vagy az adott bizottság elnöke jegyzőkönyvvezetőt kér fel.
+		\item a Választmány Közgyűlés által való felmentése esetén a következő kiírt Közgyűlésig a Választmány feladatait ügyvezetőként átveszi. Ilyenkor a teendőkre ideiglenes tisztségviselőket nevezhet ki.
 		\item a Titkár vagy a helyette kinevezett jegyzőkönyvvezető a Közgyűlésen, a Választmány és a bizottságok ülésein készült jegyzőkönyveket aláírásával hitelesíti és iktatja.
+		\item a Választmány és a bizottságok tagjait a Collegium adminisztratív rendszerében vezeti.
 	\end{enumerate}
-	\item A Tanácsadó Testület
+	\item A Ellenőrző Bizottság
 	\begin{enumerate}
-		\item tagja tapasztalt collegisták, illetve volt collegisták, akik collegiumi éveik során felgyülemlett tudással, tanácsaikkal segítik a Választmány munkáját.
-		\item tagja lehet minden olyan (volt) collegista, akinek legfeljebb öt éve szűnt meg a collegiumi tagsága, kivéve, ha az kizárás útján történt meg,
-		\item tagjait (minimum 1 fő) a Választmány egyetértésével a Választmány elnöke kéri fel,
-		\item tagjai kötelezően meghívottként, tanácskozási joggal részt vesznek a Választmány és a Közgyűlés ülésein,
-		\item tisztségük az elnök mandátumának lejártáig érvényes.
+		\item tagjai a mindenkori Titkár és a Kuratóriumi Diáktagok, póttagokkal együtt. Elnöke a mindenkori Titkár.
+		\item a c. iii. pontba foglaltak teljesülése esetén Közgyűlést hívhat össze. 
+		\item feladata a választmányi tagok programjában, a jelen Alapszabályzatban, illetve a pénzügyi tervezetben leírtak megvalósulásának ellenőrzése, számonkérése.
+		\begin{enumerate}
+			\item Ennek módját a d. pont fogalmazza meg.
+			\item Amennyiben félév közben észleli a programtól való radikális eltérést, azt köteles a Választmány felé jelezni. Ebben az esetben az Ellenőrző Bizottság elnöke kötelezheti a választmányi elnököt rendkívüli választmányi ülés összehívására.
+			\item Amennyiben a Választmány a jelzés ellenére sem változtat a kifogásolt magatartáson, az Ellenőrző Bizottság köteles ülést összehívni, melyen a Bizottsági tagok Közgyűlés összehívása mellett dönthetnek.
+		\end{enumerate}
+		\item félévente legalább egyszer ülésezni köteles.
+		\begin{enumerate}
+			\item Az üléseket az Ellenőrző Bizottság elnöke hívja össze.
+			\begin{enumerate}
+				\item Amennyiben az Ellenőrző Bizottság 2 tagja írásos úton ezt kéri, a kérés beérkezésétől számított 3 napon belül az Ellenőrző Bizottság elnöke köteles  1 héten belül ülést összehívni.
+			\end{enumerate}
+			\item Az ülések zártak, rajtuk csak az Ellenőrző Bizottság tagjai vehetnek részt. Határozatképességhez a tagság legalább 60%-ának jelen kell lennie.
+			\item A Választmány írásos beszámolójának beérkezése után, de az adott Közgyűlés előtt, annak értékelése céljából ülést kell tartania.
+			\item A c. ii. pontját ülés összehívása nélkül, a tagok szótöbbsége támogatása mellett érvényesítheti.
+			\item A c. iii. pontja értelmében ülést kell összehívnia, amelyen a tagok egyszerű többségének támogatásával a Közgyűlés összehívása mellett dönthet.
+			\begin{enumerate}
+				\item Az így összehívott Közgyűlésen az Ellenőrző Bizottság a kifogásolt problémákat bemutatni köteles, a Választmány problémában érintett tagjai védelmi beszédet mondanak. Ezen pontok megvitatása után a Közgyűlés a Választmány visszahívásáról szavaz.
+			\end{enumerate}
+		\end{enumerate}
+		\item a félévenkénti közgyűléseken a Választmányt beszámoltatja.
+		\begin{enumerate}
+			\item A Választmányi tagok írásos beszámolójukat előzetesen a tagság mellett az Ellenőrző Bizottságnak közvetlenül is elküldik.
+			\item A Közgyűlésen a kiküldött beszámolók alapján az Ellenőrző Bizottság kérdéseket intéz a Választmány tagjaihoz.
+		\end{enumerate}
+		\item tagjai kötelező meghívottjai a Választmány üléseinek.
 	\end{enumerate}
 \end{enumerate}
 
+\section{A Választmányt segítő szervek}
+
+\begin{enumerate}
+	\item A Tanácsadó Testület
+	\begin{enumerate}
+		\item tagjai tapasztalt collegisták, illetve volt collegisták, akik collegiumi éveik során felgyülemlett tudással, tanácsaikkal segítik a Választmány munkáját.
+		\item tagja lehet minden olyan (volt) collegista, akinek legfeljebb öt éve szűnt meg a collegiumi tagsága.
+		\item tagjait (minimum 3 fő) a Választmány egyetértésével a Választmány elnöke kéri fel.
+		\item tagjai kötelezően meghívottként, tanácskozási joggal részt vesznek a Választmány és a Közgyűlés ülésein.
+		\item tisztségük az elnök mandátumának lejártáig érvényes.
+	\end{enumerate}
+\end{enumerate}
 
 \section{A Választmány működése}
 
 \begin{enumerate}
 	\item A Választmány üléseit az elnök, akadályoztatása esetén valamelyik alelnöke hívja össze, készíti elő és vezeti le.
-	\item A Választmány üléseit szorgalmi időszakban legalább havonta egyszer össze kell hívni. Rendkívüli esetben, ha azt az elnök vagy a Választmány legalább két tagja szükségesnek tartja, az igény írásbeli, a választmányi elnök hivatalos e-mail címére küldött bejelentésétől számított 3 napon belül össze kell hívni.
+	\item A Választmány üléseinek kötelező meghívottjai: a bizottsági elnökök által kinevezett referensek, az Ellenőrző Bizottság és a Tanácsadó Testület tagjai.
+	\item A Választmány üléseit szorgalmi időszakban legalább havonta egyszer össze kell hívni. Rendkívüli esetben, ha azt az elnök vagy a Választmány legalább két tagja szükségesnek tartja, az igény írásbeli, a választmányi elnök hivatalos e-mail-címére küldött bejelentésétől számított 3 napon belül össze kell hívni.
 	\item A Választmány ülésein kerül sor a Választmány hatáskörébe tartozó feladatok kiosztására, a bizottságok munkájának összehangolására, valamint a Választmány tagjai által benyújtott felterjesztések megvitatására és megszavazására.
-	\item A választmányi elnök, az alelnökök és a bizottsági elnökök a Választmány ülésein kötelesek beszámolni az azt megelőző választmányi ülés óta eltelt időben végzett munkájukról.
+	\item A választmányi elnök, az alelnökök és a bizottsági elnökök a Választmány ülésein kötelesek beszámolni az azt megelőző választmányi ülés óta eltelt időben végzett munkájukról, ide értve a kinevezett referensek által végzett munkát is.
 	\item A bizottsági elnökök a kinevezett bizottsági tagok közül hivatalos meghatalmazással delegálhatnak egy főt a Választmány ülésére.
-	\item A bizottsági tagokat a bizottsági elnök nevezi ki.
-	\item A Tanácsadó Testület tagjait a választmányi elnök vagy valamely alelnök javaslatára a Választmány egyszerű szótöbbséggel való javaslata után a választmányi elnök kéri fel.
-	\item A Választmány ülései nyilvánosak, annak helyét, idejét és napirendi pontjait a választmányi ülést megelőzően 2 nappal előre közölni kell a Választmány és a CHÖK tagjaival és a meghívottakkal.
-	\item A Választmány ülesein a CHÖK minden tagja tanácskozási joggal jelen lehet.
-	\item A Választmány a választmányi ülésen egyszerű szótöbbséggel a választmányi elnök vagy alelnökök javaslatára felmentheti tisztségéből a bizottságok elnökeit. Ebben az esetben a megüresedett posztot a választmányi elnök javaslatára 10 munkanapon belül a Választmány határozata alapján új bizottsági elnök tölti be. Az új bizottsági elnök hivatalba lépéséig feladatait a választmányi elnök vagy az illetékes alelnök látja el.
+	\item A Tanácsadó Testület tagjait (legalább 3 főt) a választmányi tagok szótöbbségű javaslatára a választmányi elnök kéri fel.
+	\item A Választmány ülései nyilvánosak, annak helyét, idejét és napirendi pontjait a választ- mányi ülést megelőzően 2 nappal előre közölni kell a Választmánnyal, a CHÖK tagjaival és a meghívottakkal.
+	\item A Választmány ülésein a CHÖK minden tagja tanácskozási joggal jelen lehet.
 	\item Határozathozatal a Választmányban:
 	\begin{enumerate}
-		\item A választmányi ülés határozatképes, ha tagjainak több mint fele jelen van. A határozathozatalhoz a jelenlevők egyszerű többségének egybehangzó szavazata szükséges. Szavazategyenlőség esetén az elnök szavazata dönt.
-		\item Határozatképtelenség esetén legkésőbb 8 napon belül megismételt választmányi ülést kell összehívni, amely minden esetben határozatképes.
+		\item A választmányi ülés határozatképes, ha tagjainak több mint fele jelen van. A határozathozatalhoz a jelenlevők egyszerű többsége szükséges. Szavazategyenlőség esetén az elnök szavazata dönt.
+		\item Határozatképtelenség esetén legkésőbb ugyanazon naptári hónapon vagy 8 napon belül megismételt választmányi ülést kell összehívni.
 		\item Titkos szavazásra kerül sor:
 		\begin{enumerate}
 			\item valamennyi személyi kérdésben,
@@ -345,110 +461,179 @@ Az Eötvös Loránd Tudományegyetem (továbbiakban ELTE) Eötvös József Colle
 	\item A Választmány üléseiről jegyzőkönyvet kell készíteni, melyet a jegyzőkönyvvezető, az elnök és a Választmány egyik tagja aláírásával hitelesít, és a Titkár iktat.
 \end{enumerate}
 
-
 \section{A Választmány választása}
 
 \begin{enumerate}
-	\item A Választmány elnökét, alelnökeit és a bizottságok elnökeit a Közgyűlés választja listás szavazással.
-	\item A bizottsági tagokat a bizottsági elnök javaslatára az alelnökök egyetértésével a Választmány elnöke nevezi ki a Választmány alakuló ülésén. A kinevezésekről jegyzőkönyv készül.
-	\item A választás lebonyolítására a választó Közgyűlésen, a leköszönő Választmány beszámolóinak meghallgatása után kerül sor. A választó Közgyűlést minden évben legkésőbb október 1-jéig össze kell hívni.
-	\item A jelöltállítás:
+    \item A Választmány elnökét, alelnökeit és a bizottságok elnökeit a Közgyűlés választja listás szavazással.
+    \item A választás lebonyolítására a választó Közgyűlésen, a leköszönő Választmány beszámolóinak meghallgatása után kerül sor. A választó Közgyűlést minden évben legkésőbb október 1-jéig össze kell hívni.
 	\begin{enumerate}
-		\item A CHÖK minden tagja választhat és választható a 14.§ figyelembevételével. Listát bárki állíthat, a listán a Választmány elnöke, alelnökei és a bizottságok elnökei kötelezően szerepelnek. A listát az elnökjelöltnek a tanévnyitó Közgyűlés kihirdetését követő öt napon belül a Közgyűlést kihirdető választmányi elnök hivatalosan iktatott címére el kell juttatnia, a választmányi elnök pedig azt a kézhezvételétől számított 24 órán belül köteles a CHÖK minden tagja számára nyilvánosságra hozni.
-		\item A lista állításával a Közgyűlésen az elnökjelölt, mint a listán szereplő személyek képviselője, nyilatkozni köteles, hogy a listán szereplő személyeknek a kívánt tisztség betöltését akadályozó körülményről nincs tudomása, és hogy azok vállalják a jelölést.
-		\item A listán szereplő személyekről a Közgyűlés egyetlen szavazással, egyszerű többséggel dönt. A szavazólapon a listák valamennyi tagjának neve szerepel a 8. § 1.-ben meghatározott sorrendben. A Közgyűlés minden mandátummal rendelkező tagja legfeljebb egy listára szavazhat.
+        \item Kivételt képez ez alól az az eset, amelyben a Választmány mandátuma március 1-jéig tart. Ekkor a választó Közgyűlést legkésőbb március 1-jéig kell összehívni.
 	\end{enumerate}
-	\item A választás eredményét 7 munkanapon belül meg kell küldeni a Collegium igazgatójának, a rektornak, valamint nyilvánossá kell tenni a CHÖK és a Collegium más intézményei tagjainak, az EHÖK-nek és a KolHÖK-nek. (vö. ESZ. 22. §)
+    \item A jelöltállítás:
+		\begin{enumerate}
+    	\item A CHÖK minden tagja választhat és választható a 17.§ figyelembevételével. Listát bárki állíthat, a listán a Választmány elnöke, alelnökei és a bizottságok elnökei kötelezően szerepelnek. A listát az elnökjelöltnek a tanévnyitó Közgyűlés kihirdetését követő öt napon belül a Közgyűlést kihirdető választmányi elnök hivatalosan iktatott címére el kell juttatnia, a választmányi elnök pedig azt a kézhezvételétől számított 24 órán belül köteles a CHÖK minden tagja számára nyilvánosságra hozni.
+    	\item A lista állításával a Közgyűlésen az elnökjelölt, mint a listán szereplő személyek képviselője, nyilatkozni köteles, hogy a listán szereplő személyeknek a kívánt tisztség betöltését akadályozó körülményről nincs tudomása, és hogy azok vállalják a jelölést.
+    	\item A listán szereplő személyekről a Közgyűlés egyetlen szavazással, egyszerű többséggel dönt. A szavazólapon a listák valamennyi tagjának neve szerepel a 8. § 1.-ben meghatározott sorrendben. A Közgyűlés minden mandátummal rendelkező tagja legfeljebb egy listára szavazhat.
+	\end{enumerate}
+    \item A választás eredményét 7 munkanapon belül meg kell küldeni a Collegium igazgatójának, a rektornak, valamint nyilvánossá kell tenni a CHÖK és a Collegium más intézményei tagjainak, az EHÖK-nek és a KolHÖK-nek.
 \end{enumerate}
 
 
 \section{A Kuratórium diáktagjainak választása}
 
 \begin{enumerate}
-	\item A Collegium Kuratóriuma diáktagjainak számáról (3 fő) az SZMSZ rendelkezik. Választásuk jelen szabályzat értelmében a következőképp történik: 
-	\begin{enumerate}
-		\item A tagokat a Közgyűlés választja.
-		\item A CHÖK minden tagja választ és választható. Jelöltet bármely CHÖK tag állíthat a 14.§ figyelembevételével.
-		\item A szavazás titkos. Érvényességéhez legalább 4 jelölt állítása szükséges. Ennek hiányában a Közgyűlést egy hónapon belül meg kell ismételni.
-		\item Egy személy legfeljebb 3 jelöltre szavazhat.
-		\item A három legtöbb szavazatot kapott jelölt a Kuratórium rendes tagja, a negyedik az első, az ötödik a második póttagjai lesznek a Kuratórium diáktagjainak.
-		\item A diáktag megbízása legfeljebb egy évig (októbertől októberig), lemondásig vagy visszahívásig tart. Egy écves megbízatás esetén a diáktag mandátuma
-		\begin{enumerate}
-			\item tavaszi félévben történő megválasztás esetén a rákövetkező évbeli március 1-ig érvényes;
-			\item őszi félévben történő megválasztás esetén a rákövetkező évbeli október 1-ig érvényes.
-		\end{enumerate} 
-		\item Az első póttag valamely rendes tag távolmaradása esetén köteles megjelenni a Kuratórium ülésén. Ebben az esetben szavazati joga is van.
-		\item A második póttag két rendes tag, vagy egy rendes tag és az első póttag indokolt távolmaradása esetén köteles megjelenni a Kuratórium ülésén. Ebben az esetben szavazati joga is van.
-		\item Az első póttag valamely rendes tag lemondása, visszahívása esetén automatikusan annak helyébe lép, a második póttag pedig az első póttag helyébe lép. Ilyenkor második póttagot kell választani.
-		\item A kuratóriumi diáktagok a Kuratórium ülése utáni első választmányi ülésen kötelesek beszámolni a Kuratóriumban végzett munkájukról.
+	\item A Collegium Kuratóriuma diáktagjainak számáról (3 fő) az SzMSz 21. § (1) rendelkezik. Választásuk jelen szabályzat értelmében a következőképp történik:
+	\item A tagokat a Közgyűlés választja.
+	\item A CHÖK minden tagja választ és választható. Jelöltet bármely CHÖK-tag állíthat a 17.§ figyelembevételével.
+	\begin{enumerate} 
+		\item Kuratóriumi Diáktag a Collegium passzív státuszú hallgatója is lehet, ezzel a tisztség az 1.§ (6) a. pontnak megfelelő.
 	\end{enumerate}
+	\item A szavazás titkos. Érvényességéhez legalább 5 jelölt állítása szükséges. Ennek hiányában a Közgyűlést egy hónapon belül meg kell ismételni.
+	\item Egy személy legfeljebb 3 jelöltre szavazhat.
+	\item A három legtöbb szavazatot kapott jelölt a Kuratórium rendes tagja, a negyedik az első, az ötödik a második póttagjai lesznek a Kuratórium Diáktagoknak.
+	\begin{enumerate} 
+		\item Szavazategyenlőség esetén, amennyiben az a 3-4-5. helyek valamelyikén történt, az azonos szavazatszámmal rendelkező jelöltek között új szavazást kell kiírni egészen addig, ameddig a szavazategyenlőség fel nem oldódik.
+	\end{enumerate}
+	\item A diáktag megbízatása legfeljebb egy naptári évig, lemondásig vagy visszahívásig tart. Egy éves megbízatás esetén a diáktag mandátuma
+	\begin{enumerate}
+		\item tavaszi félévben történő megválasztás esetén a rákövetkező évbeli március 1-ig érvényes;
+		\item őszi félévben történő megválasztás esetén a rákövetkező évbeli október 1-ig érvényes.
+	\end{enumerate}
+	\item Az első póttag valamely rendes tag távolmaradása esetén köteles megjelenni a Kuratórium ülésén. Ebben az esetben szavazati joga is van.
+	\item A második póttag két rendes tag, vagy egy rendes tag és az első póttag indokolt távolmaradása esetén köteles megjelenni a Kuratórium ülésén. Ebben az esetben szavazati joga is van.
+	\item Az első póttag valamely rendes tag lemondása, visszahívása esetén automatikusan annak helyébe lép, a második póttag pedig az első póttag helyébe lép. Ilyenkor második póttagot kell választani.
+	\item A Kuratóriumi Diáktagok a Kuratórium ülése utáni első választmányi ülésen kötelesek beszámolni a Kuratóriumban végzett munkájukról.
 \end{enumerate}
 
 
 \section{A műhelytitkár}
 
 \begin{enumerate}
-	\item A műhelyek működését az SzMSz 40–48. § szabályozza.
-	\item A műhelytitkár
+	\item A műhelyek működését az SzMSz 45--53. § szabályozza.
+    \item A műhelytitkár
 	\begin{enumerate}
-		\item a műhelytagok által a félévnyitó műhelygyűlésen egy évre megválasztott tisztségviselő (vö. SzMSz 47. § (1) e.),
-		\item feladata a műhely tagságának képviselete és tájékoztatása,
-		\item tisztsége alapján mandátummal rendelkezik a Tudományos Bizottság kiterjesztett ülésein,
-		\item a műhelygyűlésen tisztségéből visszahívható,
-		\item tisztsége megszűnik collegiumi tagsága megszűntével, visszahívása vagy lemondása esetén.
+        \item a műhelytagok által a félévnyitó műhelygyűlésen egy évre megválasztott tisztségviselő (vö. SzMSz 52. § (1) e)).
+        \item feladata
+		\begin{enumerate}
+            \item mandátuma lejárta vagy lemondása esetén, a következő műhelygyűlés előtt legalább 3 nappal a műhelyszabályzatban feltüntetett hivatalos kommunikációs csatornán tájékoztatni a műhely tagságát arról, hogy a műhelygyűlésen új műhelytitkár választására kerül sor.
+			\begin{enumerate}
+                \item Amennyiben a műhelyszabályzat nem definiál hivatalos kommunikációs csatornát, a műhelytitkár feladata szorgalmazni az ilyen irányú módosítást.
+			\end{enumerate}
+            \item megválasztása után legkésőbb 3 nappal tájékoztatni, a CHÖK hivatalos kommunikációs csatornáin keresztül, a CHÖK tagjait, illetve külön a szakmai alelnököt a műhelytitkárcseréről.
+            \item a műhely tagságának képviselete és tájékoztatása.
+            \item műhelytagság figyelmének felhívása, a műhelyszabályzatban feltüntetett hivatalos kommunikációs csatornán a félév eleji státusznyilatkozat, illetve a félév végi tanulmányi előremenetelt felmérő beszámoló kitöltésére.
+            \item a Collegium reprezentatív felületein a műhellyel kapcsolatos információk (pl. műhelyhonlapok) frissítésének biztosítása.
+            \item a műhelyben fellépő belső problémákat a műhelyvezető felé jelezni.
+            \item a műhelyvezetővel kapcsolatos problémákat a Választmány szakmai alelnöke felé jelezni.
+		\end{enumerate}
+        \item tisztsége alapján mandátummal rendelkezik a Műhelytitkári Fórum ülésein.
+        \item a műhelygyűlésen tisztségéből visszahívható.
+        \item tisztsége megszűnik collegiumi tagsága megszűntével, visszahívása vagy lemondása esetén.
 	\end{enumerate}
-	\item A műhelynek lehetősége van műhelytitkár-helyettes választására.
-	\item A műhelytitkár-helyettes
+    \item A műhelynek lehetősége van műhelytitkár-helyettes választására.
+    \item A műhelytitkár-helyettes
 	\begin{enumerate}
-		\item a műhelytagok által a félévnyitó műhelygyűlésen egy évre megválasztott tisztségviselő (vö. SzMSz 47. § (1) f.),
-		\item feladata a műhelytitkár segítése,
-		\item a műhelytitkár akadályoztatottsága esetén mandátummal rendelkezik a Tudományos Bizottság kiterjesztett ülésein,
-		\item a műhelygyűlésen tisztségéből visszahívható,
-		\item tisztsége megszűnik collegiumi tagsága megszűntével, visszahívása vagy lemondása esetén.
+        \item a műhelytagok által a félévnyitó műhelygyűlésen egy évre megválasztott tisztségviselő (vö. SzMSz 52. § (1) f)).
+        \item feladata a műhelytitkár segítése.
+        \item a műhelytitkár lemondása esetén a következő műhelygyűlésig ideiglenes műhelytitkárként átveszi a műhelytitkár összes feladatát.
+        \item a műhelytitkár akadályoztatása esetén mandátummal rendelkezik a Műhelytitkári Fórum ülésein.
+        \item a műhelygyűlésen tisztségéből visszahívható.
+        \item tisztsége megszűnik collegiumi tagsága megszűntével, visszahívása vagy lemondása esetén.
 	\end{enumerate}
+    \item Amennyiben a műhelytitkár nem továbbítja a szakmai alelnök által jogosan elvárt információkat, a szakmai alelnök ajánlására a gazdasági alelnök felfüggesztheti a műhelykeret folyósítását a kért adatok beérkezéséig.
 \end{enumerate}
 
-
-\section{A CHÖK irodája}
+\section{Etikai Biztosok}
 
 \begin{enumerate}
-	\item A CHÖK feladatainak ellátására a CHÖK irodát működtet.
-	\item Az iroda szervezetét és működési rendjét a bizottsági elnökök és az elnök javaslatára a választmányi ülés fogadja el.
-	\item Az iroda szervezeti és működési rendjéért a Választmány a felelős.
-	\item Az iroda:
+	\item Az Etikai Biztosok száma minden esetben két fő. Egy nő és egy férfi collegista.
 	\begin{enumerate}
-		\item a közösségi élet elengedhetetlenül fontos kellékeit hivatott tárolni, melyeket más helységben elhelyezni nem lehet;
-		\item információs hátteret biztosítanak a hallgatók számára, vagyis a korábbi jegyzőkönyveknek, az aktuális szabályzatoknak benn olvasható példányait tárolják.
+		\item Az Etikai Biztosokat a Közgyűlés választja.
+		\item Az Etikai Biztosok a Választmánytól függetlenül működnek, kivéve, lásd: 16. § (4).
+		\item A CHÖK minden tagja választ és választható. Jelöltet bármely CHÖK tag állíthat a 17.§ (5) figyelembevételével.
+		\item A szavazás titkos. Érvényességéhez legalább 4 jelölt (legalább 2 nő és 2 férfi) állítása szükséges. Ennek hiányában a Közgyűlést egy hónapon belül meg kell ismételni.
+		\item Egy személy legfeljebb két jelöltre szavazhat: egy nőre és egy férfira. Amennyiben több azonosnemű jelöltre is szavaz, szavazata érvénytelen.
+		\item A legtöbb szavazatot kapott nő és férfi lesznek az Etikai Biztosok. A második legtöbb szavazatot szerző nő és férfi collegisták pedig a pótbiztosok, lásd: 16. § (1) i. 
+		\item A Biztosok megbízása legfeljebb egy félévig, lemondásig vagy visszahívásig tart. 
+		\begin{enumerate}
+			\item tavaszi félévben történő megválasztás esetén a rákövetkező október 1-ig érvényes;
+			\item őszi félévben történő megválasztás esetén a rákövetkező évbeli március 1-ig érvényes.
+		\end{enumerate}
+		\item Bármelyik rendes Közgyűlésen újraválaszthatók.
+		\item Amennyiben a Biztos(ok) diszkréciója erősen megkérdőjelezhetővé válik, úgy a zárt választmányi ülés egyhangúsággal szavazhat a Biztos(ok) visszahívásáról, ekkor a Közgyűlésen második legtöbb szavazatot elért jelölt lép a helyére a következő Közgyűlésen esedékes választásig.
 	\end{enumerate}
-	\item Az iroda házirendje a jelen Alapszabály mellékletének minősül.
+	\item Az Etikai Biztosok feladatköre
+	\begin{enumerate}
+		\item Az Etikai Biztosok feladata az elektronikus platformokon keresztül a saját alias-os e-mail-címükre érkező levelek rendszeres olvasása. 
+		\item Az Etikai Biztosok küldenek egy-egy néhány mondatos beszámolót minden választmányi ülésre a munkájukról.
+		\item Az Etikai Biztosok ezenfelül elhelyezhetnek tájékoztató jellegű és prevenciós anyagokat a Collegiumban.
+	\end{enumerate}
+	\item Kapcsolatteremtés az Etikai Biztosokkal
+	\begin{enumerate}
+		\item Az Etikai Biztosokat elektronikus platformokon keresztül, a saját alias-os e-mail-címükre küldött üzenetekkel lehet elérni, valamint személyesen is felkereshetők.
+		\item Anonim módon írt e-mailek esetén
+		\begin{enumerate}
+			\item nem indulhat kivizsgálás vagy eljárás,
+			\item ebben az esetben a Biztosok feladata a tájékoztatás a felmerülő lehetőségekről, tanácsadás és lelki segítség nyújtása,
+			\item kivételt képez ez alól, amennyiben önmaga vagy más ellen irányuló komoly testi sértés szándékának megalapozott gyanúja áll fenn. Ebben az esetben a Biztosok feladata a szakellátás, illetve szakember ajánlása, valamint a Választmány értesítése.
+		\end{enumerate}
+		\item Nem anonim módon írt üzenetek vagy személy felkeresés esetén
+		\begin{enumerate}
+			\item a Biztosok feladata a kivizsgálás megindítása, amennyiben az érintett személy ezt kéri, valamint személyre szabott segítség nyújtása, 
+			\item amennyiben az adott ügy a Collegium valamely, az üzenet küldőjén kívül megnevezett tagját, a Collegium vezetőségét, tanárát, vagy dolgozóit érinti, amennyiben törvénysértésről számol be, a Biztosoknak kötelessége értesíteni a Választmányt, a Választmány elé tárni az ügy részleteit.
+		\end{enumerate}
+	\end{enumerate}
+	\item A Választmány feladata
+	\begin{enumerate}
+		\item A választmányi elnök zárt választmányi ülést hív össze, amennyiben a 16. § (3) c. ii. pontja szerinti értesítést kap a Biztosoktól. 
+		\item A választmányi ülésen kizárólag a Választmány tagjai, a Titkár, valamint az Etikai Biztosok és az érintett(ek) vehetnek részt, megvitatják a kivizsgálást, intézkedést igénylő eseteket. 
+		\item Amennyiben szükséges a választmányi elnök az igazgató elé tárja az ügy részleteit, hogy megindulhasson a szakkollégiumi vagy az egyetemi fegyelmi eljárás. A Biztosok feladata ilyen esetekben a sérült fél, felek támogatása, a fegyelmi eljárás részleteinek és az eljárás menetének ismertetése velük. 
+		\item Az Etikai Biztosok elleni kifogást a Választmánynak lehet benyújtani, vö. 16. § (1) i.
+	\end{enumerate}
 \end{enumerate}
 
 \section{Összeférhetetlenség}
 
 \begin{enumerate}
 	\item A CHÖK tisztségviselői pozícióiból többet egy személy nem tölthet be.
-	\item A CHÖK tisztségviselője nem lehet
+    \item Választmányi tag nem lehet
 	\begin{enumerate}
-		\item kuratóriumi diáktag,
-		\item műhelytitkár vagy műhelytitkár-helyettes,
-		\item bizottsági elnök és bizottsági tag,
-		\item Titkár
+		\item Kuratóriumi Diáktag,
+        \item műhelytitkár vagy műhelytitkár-helyettes,
+        \item bizottsági tag,
+        \item Titkár,
+        \item Etikai Biztos.
 	\end{enumerate}
 	\item A Titkár nem lehet
 	\begin{enumerate}
-		\item a Választmány tagja
-		\item műhelytitkár vagy műhelytitkár-helyettes
-		\item bizottsági tag
+        \item a Választmány tagja,
+        \item műhelytitkár vagy műhelytitkár-helyettes,
+        \item bizottsági tag,
+        \item Kuratóriumi Diáktag,
+        \item Etikai Biztos.
 	\end{enumerate}
-	\item Műhelyvezető nem lehet kuratóriumi diáktag.
-	\item Amennyiben a Tudományos Bizottság elnöke műhelytitkár is egyben, úgy a kiterjesztett tudományos bizottsági ülésen egy szavazattal rendelkezik.
+	\item Műhelyvezető nem lehet 
+	\begin{enumerate}
+        \item a Választmány tagja,
+        \item Kuratóriumi Diáktag,
+        \item Etikai Biztos.
+	\end{enumerate}
+	\item Etikai Biztos nem lehet
+	\begin{enumerate}
+        \item a Választmány tagja,
+        \item Titkár,
+        \item Kuratóriumi Diáktag,
+        \item műhelyvezető.
+	\end{enumerate}
+    \item Az eseti (ad-hoc) bizottság elnökére az esetleges összeférhetetlenséget a Választmány állapítja meg, döntése felett a Titkárnak felülbírálati joga van.
 \end{enumerate}
 
 \section{Zárórendelkezések}
 
 \begin{enumerate}
 	\item Jelen szabályzat elfogadása után azonnal hatályba lép.
-	\item Jelen szabályzatot a Közgyűlés 2020. február 20-án elfogadta.
+	\item Jelen szabályzatot a Közgyűlés 2022. szeptember 15-én elfogadta.
 	\item Jelen szabályzat egy példányát a Collegium könyvtárában el kell helyezni, valamint a Collegium honlapján elérhetővé kell tenni.
 \end{enumerate}
+
 \end{document}


### PR DESCRIPTION
A CHÖK-alapszabály 2022. szeptember 15-én elfogadott módosításának LaTeX-re alakított változata.
Különösen fontos egy jól átlátható formában is archiválni a szabályzatokat, hogy utólag is jól követhető legyen, hogy mikor milyen jellegű módosítások történtek a szabályokban, hogy ezáltal a jövőbeli módosítások a múlt hibáiból tanulva jöhessenek létre.

Még átnézést igényel.